### PR TITLE
Add Disqus support (opt-in)

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -52,6 +52,25 @@
         </footer>
 
         {{/post}}
+    
+    <!-- Disqus comments
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = '%YOURDISQUSNAME%';
+        
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        var disqus_identifier = '{{post.id}}';
+
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a> 
+    -->
 
     </article>
 


### PR DESCRIPTION
I thought this might be useful for the one or two. 

If you want to enable Disqus comments, simply remove the `-->` in line 73 and append it on line 56. Last but not least, adjust `%YOURDISQUSNAME%` to your Disqus shortname.

You can find a demo of this [here](http://blog.frd.mn/the-centos-disc-was-not-found-in-any-of-your-drives/). 

PS: Make sure you've set the "Color scheme" of Disqus "for light backgrounds" in Settings -> General -> Appearance:
![bildschirmfoto 2013-10-28 um 11 35 22](https://f.cloud.github.com/assets/944459/1418749/fd19d276-3fbc-11e3-9f0e-29c780f6c63b.png)
