### PR TITLE
Fixed issue where the Disqus auto color scheme was incorrectly selecting the dark scheme.

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -282,6 +282,9 @@ footer.post-footer {
   border-top: 1px solid #ecf0f1;
   margin-top: 1em;
 }
+#disqus_thread {
+  color: #787878; 
+}
 /* === Navigation and Pagination === */
 nav {
   border-bottom: 1px solid #ecf0f1;

--- a/post.hbs
+++ b/post.hbs
@@ -54,22 +54,23 @@
         {{/post}}
     
     <!-- Disqus comments
-    <div id="disqus_thread"></div>
-    <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '%YOURDISQUSNAME%';
-        
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        var disqus_identifier = '{{post.id}}';
+    <div id="disqus_thread">
+        <script type="text/javascript">
+            /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+            var disqus_shortname = '%YOURDISQUSNAME%';
+            
+            /* * * DON'T EDIT BELOW THIS LINE * * */
+            var disqus_identifier = '{{post.id}}';
 
-        (function() {
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-    </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a> 
+            (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+        </script>
+        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+        <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    </div> 
     -->
 
     </article>


### PR DESCRIPTION
Added a css rule to change body color for Disqus div.
Reformatted Disqus comments to be inside disqus_thread div.

I am running with these changes, you can see an example here:
http://travispavek.com/google-search-your-relationships/

Before:
![Disqus before fix](https://f.cloud.github.com/assets/1483906/2156911/6914a13c-946c-11e3-85a1-b7ccbd04f8e1.png)

After:
![Disqus after fix](https://f.cloud.github.com/assets/1483906/2156913/70deaca0-946c-11e3-9e17-f29b69f33053.png)
