### PR TITLE
Fix for weird spacing of twitter icon in firefox

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -452,7 +452,6 @@ a.archive-link {
 }
 .icon-twitter:before {
   content: "\e002";
-  font-size: 1.1em;
 }
 .icon-google-plus:before {
   content: "\e003";

--- a/assets/css/screen.less
+++ b/assets/css/screen.less
@@ -508,7 +508,6 @@ a.archive-link {
 
 .icon-twitter:before {
     content: "\e002";
-    font-size: 1.1em;
 }
 
 .icon-google-plus:before {


### PR DESCRIPTION
I don't know what the 1.1em property was for, or if it addressed a specific issue. (So this might be incorrect).

However, AFAICT this removes the [firefox issue with the sharing button](https://github.com/sethlilly/Vapor/issues/17) while keeping safari and chrome the same.
