### PR TITLE
Fix navigation menu margin for last child

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -327,9 +327,6 @@ nav.menu li {
   margin: 0 .5em;
   padding: 0;
 }
-nav.menu li:last-child {
-  margin: 0;
-}
 @media only screen and (min-width: 320px) and (max-width: 662px) {
   nav.menu li {
     display: block;


### PR DESCRIPTION
Before:

![not enough spacing before last item](https://cloud.githubusercontent.com/assets/126538/2813177/bf91d542-ce7e-11e3-9288-08c1e18ceb12.png)

After:

![equal spacing between items](https://cloud.githubusercontent.com/assets/126538/2813180/e579dc78-ce7e-11e3-8bf1-077a18d3da6f.png)
