### PR TITLE
- Add facebook og tags into each post.

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -17,6 +17,7 @@
     {{#if pagination.next}}<link href="{{pageUrl pagination.next}}" rel="prefetch" />{{/if}}
 
     {{ghost_head}}
+    {{{block "metaTags"}}}
 </head>
 <body class="{{body_class}}">
 

--- a/post.hbs
+++ b/post.hbs
@@ -5,7 +5,13 @@
     <article class="{{post_class}}">
 
         {{#post}}
-
+        {{#contentFor "metaTags"}}
+            <meta property="og:title" content="{{title}}" />
+            <meta property="og:url" content="{{url absolute="true"}}"/>
+            <meta property="og:description" content="{{excerpt}}"/>
+            <meta property="article:author" content="{{author.website}}">
+            <meta property="og:type" content="article">
+        {{/contentFor}}
         <header>
         {{#if tags}}<div class="post-meta tags">Posted in {{tags}}</div>{{/if}}
         <h1 class="post-title">{{{title}}}</h1>


### PR DESCRIPTION
Thanks for the absolutely fantastic theme (I love it and am using it on http://blog.siddhuw.info). However, I found that the Facebook Share button scraped the screen and produced a share description that was unreadable. So, I've used express-hbs content blocks (see [here](dev.ghost.org/ghost-theme-tips-defining-content-blocks/)) to add [facebook OpenGraph tags](https://developers.facebook.com/docs/opengraph/using-objects) to each post.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sethlilly/vapor/32)
<!-- Reviewable:end -->
