### PR TITLE
Fixed the google+ commenting system width if enabled

### DIFF
--- a/assets/css/normalize.css
+++ b/assets/css/normalize.css
@@ -404,3 +404,12 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+
+/*
+ * Prevent google+ comment system from creating horizontal scroll on 
+ * mobile devices
+ * http://www.andrea-cardinale.com/css/make-responsive-the-google-plus-comments-widget.html
+ */
+div[id^='___comments_'], div[id^='___comments_'] iframe {
+  width: 100% !important;
+}


### PR DESCRIPTION
If someone enables the  google+ commenting system, when the blog is loaded on a mobile device that does not have a width greater than or equal to 600px, the page will load at 601 px cuasing the blog to no longer be "horizontally locked" which can annoy the user as the "drift" sideways whilst scrolling down.
Added a CSS addition to dynamically adjust the commenting system's width to prevent this.
- This is my first ever pull request, so I hope I did things correctly.
