### PR TITLE
added {{reading_time}} for estimated reading time.

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -7,7 +7,10 @@
     <article class="preview">
         <header>
             <h1 class="post-title"><a href="{{url}}">{{{title}}}</a></h1>
-            <div class="post-meta"><time class="post-date" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}">...</time></div>
+            <div class="post-meta"><time class="post-date" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}">...</time>
+            <br>
+            {{reading_time}}
+            </div>
         </header>
         <section class="post-excerpt">
             <p>{{excerpt}}&hellip;</p>

--- a/post.hbs
+++ b/post.hbs
@@ -9,7 +9,10 @@
         <header>
         {{#if tags}}<div class="post-meta tags">Posted in {{tags}}</div>{{/if}}
         <h1 class="post-title">{{{title}}}</h1>
-        <div class="post-meta"><time class="post-date" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}">...</time></div>
+        <div class="post-meta"><time class="post-date" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}">...</time>
+        <br>
+        {{reading_time}}
+        </div>
         </header>
 
         <section class="post-content">


### PR DESCRIPTION
Hello, The default Ghost theme -Casper includes estimated reading time. Vapor does not and I find this feature useful so I added it. https://themes.ghost.org/docs/reading_time

Here's a preview: https://i.imgur.com/5bQEdIH.png